### PR TITLE
[sc-50816] Terraform is always trying to overwrite the real github secret value

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -164,6 +164,11 @@ resource "aws_ssm_parameter" "atlantis_github_user_token" {
   value = var.atlantis_github_user_token
 
   tags = local.tags
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
 }
 
 resource "aws_ssm_parameter" "atlantis_gitlab_user_token" {


### PR DESCRIPTION
I'm not sure why this isn't a wider issue...
https://github.com/headway/terraform/blob/master/modules/infrastructure/atlantis/main.tf#L27

Without `ignore_changes` the secret will get overridden with the literal `(placeholder)` value. And there doesn't seem to be a good way to avoid this. If you don't define `atlantis_github_user_token` at all, the atlantis module won't try to read from ssm for the github secret: https://github.com/headway/terraform-aws-atlantis/blob/master/main.tf#L18-L22

Are other people using this module just committing the real secret? 🤔 
Is there a different way to go about this...?